### PR TITLE
Support for custom callback plugins.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ add_executable(apex_test_runner
     tests/test_runner.c
     tests/test_basic.c
     tests/test_cmark_callback.c
+    tests/test_custom_plugins.c
     tests/test_metadata.c
     tests/test_links.c
     tests/test_tables.c

--- a/include/apex/apex.h
+++ b/include/apex/apex.h
@@ -17,6 +17,7 @@ extern "C" {
 #include "ast_markdown.h"
 #include "ast_terminal.h"
 #include "ast_man.h"
+#include <regex.h>
 
 #define APEX_VERSION_MAJOR 1
 #define APEX_VERSION_MINOR 0
@@ -55,6 +56,65 @@ typedef enum {
     APEX_OUTPUT_MAN_HTML = 11       /* styled HTML man page */
 } apex_output_format_t;
 
+
+
+/* Plugin phases */
+typedef enum {
+    APEX_PLUGIN_PHASE_PRE_PARSE  = 1 << 0,
+    APEX_PLUGIN_PHASE_BLOCK      = 1 << 1,
+    APEX_PLUGIN_PHASE_INLINE     = 1 << 2,
+    APEX_PLUGIN_PHASE_POST_RENDER= 1 << 3
+} apex_plugin_phase_mask;
+
+typedef struct apex_plugin_manager apex_plugin_manager;
+
+typedef struct apex_plugin apex_plugin;
+
+typedef struct apex_plugin {
+    char *id;
+    char *title;
+    char *author;
+    char *description;
+    char *homepage;
+    char *repo;
+    apex_plugin_phase_mask phases;
+    int priority;
+
+    char *handler_command; /* External command to be executed */
+    int timeout_ms;
+    /* Declarative regex support */
+    char *pattern;
+    char *replacement;
+    regex_t regex;
+    int has_regex;
+    /* Owning directory for this plugin (used for APEX_PLUGIN_DIR) */
+    char *dir_path;
+    /* Per-plugin support directory (used for APEX_SUPPORT_DIR) */
+    char *support_dir;
+    /* A custom callback to transform the passed text. Executed only if handler_command and has_regex are not set. */
+    char *(*callback)(const char *text, apex_plugin *plugin, apex_plugin_phase_mask phase, const struct apex_options *options);
+    struct apex_plugin *next;
+} apex_plugin;
+
+/**
+ * Initialize an empty plugin.
+ */
+apex_plugin *init_plugin(void);
+
+/**
+ * Release a plugin.
+ */
+void free_plugin(struct apex_plugin *p);
+
+/**
+ * Register a new plugin.
+ * Please note that a plugin can only be registered for one of the possible processing phase.
+ * @param manager
+ * @param plugin
+ * @return Returns true if the plugin was registered successfully.
+ */
+bool plugin_register(struct apex_plugin_manager *manager, struct apex_plugin *plugin);
+
 struct cmark_parser;  /* Opaque; for cmark_init callback. Include cmark-gfm when implementing. */
 
 /**
@@ -65,6 +125,9 @@ typedef struct apex_options {
 
     /* Feature flags */
     bool enable_plugins;  /* Enable external/plugin processing */
+    bool allow_external_plugin_detection; /* Enable detection of external plugins */
+    void (*plugin_register)(apex_plugin_manager *manager, const struct apex_options *options); /* Function to register others plugins */
+
     bool enable_tables;
     bool enable_footnotes;
     bool enable_definition_lists;

--- a/include/apex/apex.h
+++ b/include/apex/apex.h
@@ -14,10 +14,7 @@ extern "C" {
 
 #include <stddef.h>
 #include <stdbool.h>
-#include "ast_markdown.h"
 #include "ast_terminal.h"
-#include "ast_man.h"
-#include <regex.h>
 
 #define APEX_VERSION_MAJOR 1
 #define APEX_VERSION_MINOR 0
@@ -68,50 +65,11 @@ typedef enum {
 
 typedef struct apex_plugin_manager apex_plugin_manager;
 
-typedef struct apex_plugin {
-    char *id;
-    char *title;
-    char *author;
-    char *description;
-    char *homepage;
-    char *repo;
-    apex_plugin_phase_mask phases;
-    int priority;
-
-    char *handler_command; /* External command to be executed */
-    int timeout_ms;
-    /* Declarative regex support */
-    char *pattern;
-    char *replacement;
-    regex_t regex;
-    int has_regex;
-    /* Owning directory for this plugin (used for APEX_PLUGIN_DIR) */
-    char *dir_path;
-    /* Per-plugin support directory (used for APEX_SUPPORT_DIR) */
-    char *support_dir;
-    /* A custom callback to transform the passed text. Executed only if handler_command and has_regex are not set. */
-    char *(*callback)(const char *text, struct apex_plugin *plugin, apex_plugin_phase_mask phase, const struct apex_options *options);
-    struct apex_plugin *next;
-} apex_plugin;
-
 /**
- * Initialize an empty plugin.
- */
-apex_plugin *init_plugin(void);
-
-/**
- * Release a plugin.
- */
-void free_plugin(struct apex_plugin *p);
-
-/**
- * Register a new plugin.
- * Please note that a plugin can only be registered for one of the possible processing phase.
- * @param manager
- * @param plugin
+ * Register a new callback plugin.
  * @return Returns true if the plugin was registered successfully.
  */
-bool plugin_register(struct apex_plugin_manager *manager, struct apex_plugin *plugin);
+bool apex_plugin_register(apex_plugin_manager *manager, const char *id, apex_plugin_phase_mask phase, char *(*callback)(const char *text, const char *id_plugin, apex_plugin_phase_mask phase, const struct apex_options *options));
 
 struct cmark_parser;  /* Opaque; for cmark_init callback. Include cmark-gfm when implementing. */
 
@@ -124,7 +82,7 @@ typedef struct apex_options {
     /* Feature flags */
     bool enable_plugins;  /* Enable external/plugin processing */
     bool allow_external_plugin_detection; /* Enable detection of external plugins */
-    void (*plugin_register)(apex_plugin_manager *manager, const struct apex_options *options); /* Function to register others plugins */
+    void (*plugin_register)(apex_plugin_manager *manager, const struct apex_options *options); /* Function to register callback plugins */
 
     bool enable_tables;
     bool enable_footnotes;

--- a/include/apex/apex.h
+++ b/include/apex/apex.h
@@ -68,8 +68,6 @@ typedef enum {
 
 typedef struct apex_plugin_manager apex_plugin_manager;
 
-typedef struct apex_plugin apex_plugin;
-
 typedef struct apex_plugin {
     char *id;
     char *title;
@@ -92,7 +90,7 @@ typedef struct apex_plugin {
     /* Per-plugin support directory (used for APEX_SUPPORT_DIR) */
     char *support_dir;
     /* A custom callback to transform the passed text. Executed only if handler_command and has_regex are not set. */
-    char *(*callback)(const char *text, apex_plugin *plugin, apex_plugin_phase_mask phase, const struct apex_options *options);
+    char *(*callback)(const char *text, struct apex_plugin *plugin, apex_plugin_phase_mask phase, const struct apex_options *options);
     struct apex_plugin *next;
 } apex_plugin;
 

--- a/src/apex.c
+++ b/src/apex.c
@@ -2685,6 +2685,9 @@ apex_options apex_options_default(void) {
 
     /* Enable all features by default in unified mode; plugins are opt-in */
     opts.enable_plugins = false;
+    opts.allow_external_plugin_detection = true;
+    opts.plugin_register = NULL;
+
     opts.enable_tables = true;
     opts.enable_footnotes = true;
     opts.enable_definition_lists = true;
@@ -4361,9 +4364,9 @@ char *apex_markdown_to_html(const char *markdown, size_t len, const apex_options
     PROFILE_START(total);
 
     /* Use default options if none provided, and create a mutable copy */
-    apex_options default_opts;
     apex_options local_opts;
     if (!options) {
+        apex_options default_opts;
         default_opts = apex_options_default();
         local_opts = default_opts;
     } else {

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -92,35 +92,16 @@ static char *apex_git_toplevel(void) {
     return out;
 }
 
-struct apex_plugin {
-    char *id;
-    char *title;
-    char *author;
-    char *description;
-    char *homepage;
-    char *repo;
-    apex_plugin_phase_mask phases;
-    int priority;
-    char *handler_command;
-    int timeout_ms;
-    /* Declarative regex support */
-    char *pattern;
-    char *replacement;
-    regex_t regex;
-    int has_regex;
-    /* Owning directory for this plugin (used for APEX_PLUGIN_DIR) */
-    char *dir_path;
-    /* Per-plugin support directory (used for APEX_SUPPORT_DIR) */
-    char *support_dir;
-    struct apex_plugin *next;
-};
-
 struct apex_plugin_manager {
     struct apex_plugin *pre_parse;
     struct apex_plugin *post_render;
 };
 
-static void free_plugin(struct apex_plugin *p) {
+apex_plugin *init_plugin(void) {
+    return calloc(1, sizeof(struct apex_plugin));;
+}
+
+void free_plugin(struct apex_plugin *p) {
     while (p) {
         struct apex_plugin *next = p->next;
         free(p->id);
@@ -137,6 +118,7 @@ static void free_plugin(struct apex_plugin *p) {
         if (p->has_regex) {
             regfree(&p->regex);
         }
+        p->callback = NULL;
         free(p);
         p = next;
     }
@@ -207,6 +189,23 @@ static bool plugin_id_exists(struct apex_plugin *head, const char *id) {
     if (!id) return false;
     for (struct apex_plugin *p = head; p; p = p->next) {
         if (p->id && strcmp(p->id, id) == 0) return true;
+    }
+    return false;
+}
+
+bool plugin_register(apex_plugin_manager *manager, struct apex_plugin *plugin) {
+    if (!plugin || !manager) return false;
+
+    if (plugin->phases & APEX_PLUGIN_PHASE_PRE_PARSE) {
+        if (!plugin_id_exists(manager->pre_parse, plugin->id)) {
+            append_plugin_sorted(&manager->pre_parse, plugin);
+            return true;
+        }
+    } else if (plugin->phases & APEX_PLUGIN_PHASE_POST_RENDER) {
+        if (!plugin_id_exists(manager->post_render, plugin->id)) {
+            append_plugin_sorted(&manager->post_render, plugin);
+            return true;
+        }
     }
     return false;
 }
@@ -355,7 +354,7 @@ static void load_plugins_from_dir(apex_plugin_manager *manager,
                     continue;
                 }
 
-                struct apex_plugin *p = calloc(1, sizeof(struct apex_plugin));
+                struct apex_plugin *p = init_plugin();
                 if (!p) {
                     apex_free_metadata(merged);
                     continue;
@@ -478,7 +477,7 @@ static void load_plugins_from_dir(apex_plugin_manager *manager,
         }
 
         const char *final_id = id ? id : ent->d_name;
-        struct apex_plugin *p = calloc(1, sizeof(struct apex_plugin));
+        struct apex_plugin *p = init_plugin();
         if (!p) {
             apex_free_metadata(meta);
             continue;
@@ -568,66 +567,72 @@ apex_plugin_manager *apex_plugins_load(const apex_options *options) {
     apex_plugin_manager *manager = calloc(1, sizeof(apex_plugin_manager));
     if (!manager) return NULL;
 
-    /* Project-scoped (current working directory): CWD/.apex/plugins */
-    char cwd[1024];
-    cwd[0] = '\0';
-    if (getcwd(cwd, sizeof(cwd)) != NULL && cwd[0] != '\0') {
-        char *cwd_proj_dir = dup_join(cwd, ".apex/plugins");
-        if (cwd_proj_dir) {
-            load_plugins_from_dir(manager, cwd_proj_dir);
-            free(cwd_proj_dir);
-        }
+    if (options->plugin_register) {
+        options->plugin_register(manager, options);
     }
 
-    /* Project-scoped (explicit base_directory): base_directory/.apex/plugins */
-    if (options->base_directory && options->base_directory[0] != '\0') {
-        char *proj_dir = dup_join(options->base_directory, ".apex/plugins");
-        if (proj_dir) {
-            load_plugins_from_dir(manager, proj_dir);
-            free(proj_dir);
-        }
-    }
-
-    /* Project-scoped (Git repository root): <git top>/\.apex/plugins
-     * Only used when the current directory is inside the work tree.
-     */
-    char *git_root = apex_git_toplevel();
-    if (git_root && git_root[0] != '\0' && cwd[0] != '\0') {
-        size_t root_len = strlen(git_root);
-        /* Ensure the Git root is a parent of (or equal to) the current directory. */
-        if (strncmp(cwd, git_root, root_len) == 0 &&
-            (cwd[root_len] == '/' || cwd[root_len] == '\0')) {
-            /* Avoid re-loading if git_root is the same as base_directory. */
-            if (!options->base_directory ||
-                strcmp(git_root, options->base_directory) != 0) {
-                char *git_proj_dir = dup_join(git_root, ".apex/plugins");
-                if (git_proj_dir) {
-                    load_plugins_from_dir(manager, git_proj_dir);
-                    free(git_proj_dir);
-                }
+    if (options->allow_external_plugin_detection) {
+        /* Project-scoped (current working directory): CWD/.apex/plugins */
+        char cwd[1024];
+        cwd[0] = '\0';
+        if (getcwd(cwd, sizeof(cwd)) != NULL && cwd[0] != '\0') {
+            char *cwd_proj_dir = dup_join(cwd, ".apex/plugins");
+            if (cwd_proj_dir) {
+                load_plugins_from_dir(manager, cwd_proj_dir);
+                free(cwd_proj_dir);
             }
         }
-        free(git_root);
-    }
 
-    /* User-global: $XDG_CONFIG_HOME/apex/plugins or $HOME/.config/apex/plugins */
-    const char *xdg = getenv("XDG_CONFIG_HOME");
-    char *global_dir = NULL;
-    if (xdg && *xdg) {
-        char buf[1024];
-        snprintf(buf, sizeof(buf), "%s/apex/plugins", xdg);
-        global_dir = strdup(buf);
-    } else {
-        const char *home = getenv("HOME");
-        if (home && *home) {
-            char buf[1024];
-            snprintf(buf, sizeof(buf), "%s/.config/apex/plugins", home);
-            global_dir = strdup(buf);
+        /* Project-scoped (explicit base_directory): base_directory/.apex/plugins */
+        if (options->base_directory && options->base_directory[0] != '\0') {
+            char *proj_dir = dup_join(options->base_directory, ".apex/plugins");
+            if (proj_dir) {
+                load_plugins_from_dir(manager, proj_dir);
+                free(proj_dir);
+            }
         }
-    }
-    if (global_dir) {
-        load_plugins_from_dir(manager, global_dir);
-        free(global_dir);
+
+        /* Project-scoped (Git repository root): <git top>/\.apex/plugins
+         * Only used when the current directory is inside the work tree.
+         */
+        char *git_root = apex_git_toplevel();
+        if (git_root && git_root[0] != '\0' && cwd[0] != '\0') {
+            size_t root_len = strlen(git_root);
+            /* Ensure the Git root is a parent of (or equal to) the current directory. */
+            if (strncmp(cwd, git_root, root_len) == 0 &&
+                (cwd[root_len] == '/' || cwd[root_len] == '\0')) {
+                /* Avoid re-loading if git_root is the same as base_directory. */
+                if (!options->base_directory ||
+                    strcmp(git_root, options->base_directory) != 0) {
+                    char *git_proj_dir = dup_join(git_root, ".apex/plugins");
+                    if (git_proj_dir) {
+                        load_plugins_from_dir(manager, git_proj_dir);
+                        free(git_proj_dir);
+                    }
+                    }
+                }
+            free(git_root);
+        }
+
+        /* User-global: $XDG_CONFIG_HOME/apex/plugins or $HOME/.config/apex/plugins */
+        const char *xdg = getenv("XDG_CONFIG_HOME");
+        char *global_dir = NULL;
+        if (xdg && *xdg) {
+            char buf[1024];
+            snprintf(buf, sizeof(buf), "%s/apex/plugins", xdg);
+            global_dir = strdup(buf);
+        } else {
+            const char *home = getenv("HOME");
+            if (home && *home) {
+                char buf[1024];
+                snprintf(buf, sizeof(buf), "%s/.config/apex/plugins", home);
+                global_dir = strdup(buf);
+            }
+        }
+        if (global_dir) {
+            load_plugins_from_dir(manager, global_dir);
+            free(global_dir);
+        }
     }
 
     if (!manager->pre_parse && !manager->post_render) {
@@ -861,6 +866,8 @@ char *apex_plugins_run_text_phase(apex_plugin_manager *manager,
             }
         } else if (p->has_regex) {
             next = apply_regex_replacement(p, current);
+        } else if (p->callback) {
+            next = p->callback(current, p, phase, options);
         }
 
         if (do_profile) {

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -92,16 +92,43 @@ static char *apex_git_toplevel(void) {
     return out;
 }
 
+
+typedef struct apex_plugin {
+    char *id;
+    char *title;
+    char *author;
+    char *description;
+    char *homepage;
+    char *repo;
+    apex_plugin_phase_mask phases;
+    int priority;
+
+    char *handler_command; /* External command to be executed */
+    int timeout_ms;
+    /* Declarative regex support */
+    char *pattern;
+    char *replacement;
+    regex_t regex;
+    int has_regex;
+    /* Owning directory for this plugin (used for APEX_PLUGIN_DIR) */
+    char *dir_path;
+    /* Per-plugin support directory (used for APEX_SUPPORT_DIR) */
+    char *support_dir;
+    /* A custom callback to transform the passed text. Executed only if handler_command and has_regex are not set. */
+    char *(*callback)(const char *text, const char *id_plugin, apex_plugin_phase_mask phase, const struct apex_options *options);
+    struct apex_plugin *next;
+} apex_plugin;
+
 struct apex_plugin_manager {
     struct apex_plugin *pre_parse;
     struct apex_plugin *post_render;
 };
 
-apex_plugin *init_plugin(void) {
-    return calloc(1, sizeof(struct apex_plugin));;
+static apex_plugin *init_plugin(void) {
+    return calloc(1, sizeof(struct apex_plugin));
 }
 
-void free_plugin(struct apex_plugin *p) {
+static void free_plugin(struct apex_plugin *p) {
     while (p) {
         struct apex_plugin *next = p->next;
         free(p->id);
@@ -193,8 +220,16 @@ static bool plugin_id_exists(struct apex_plugin *head, const char *id) {
     return false;
 }
 
-bool plugin_register(apex_plugin_manager *manager, struct apex_plugin *plugin) {
-    if (!plugin || !manager) return false;
+bool apex_plugin_register(apex_plugin_manager *manager, const char *id, apex_plugin_phase_mask phase, char *(*callback)(const char *text,  const char *id_plugin, apex_plugin_phase_mask phase, const struct apex_options *options)) {
+    apex_plugin *plugin;
+    plugin = init_plugin();
+    if (!plugin || !manager) {
+        return false;
+    }
+
+    plugin->id = id != NULL ? strdup(id) : NULL;
+    plugin->callback = callback;
+    plugin->phases = phase;
 
     if (plugin->phases & APEX_PLUGIN_PHASE_PRE_PARSE) {
         if (!plugin_id_exists(manager->pre_parse, plugin->id)) {
@@ -867,7 +902,7 @@ char *apex_plugins_run_text_phase(apex_plugin_manager *manager,
         } else if (p->has_regex) {
             next = apply_regex_replacement(p, current);
         } else if (p->callback) {
-            next = p->callback(current, p, phase, options);
+            next = p->callback(current, p->id, phase, options);
         }
 
         if (do_profile) {

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -7,16 +7,6 @@
 extern "C" {
 #endif
 
-/* Plugin phases */
-typedef enum {
-    APEX_PLUGIN_PHASE_PRE_PARSE  = 1 << 0,
-    APEX_PLUGIN_PHASE_BLOCK      = 1 << 1,
-    APEX_PLUGIN_PHASE_INLINE     = 1 << 2,
-    APEX_PLUGIN_PHASE_POST_RENDER= 1 << 3
-} apex_plugin_phase_mask;
-
-typedef struct apex_plugin_manager apex_plugin_manager;
-
 /* Discover and load plugins from project and user config dirs.
  * Returns NULL if no plugins are found or an error occurs. */
 apex_plugin_manager *apex_plugins_load(const apex_options *options);

--- a/tests/test_custom_plugins.c
+++ b/tests/test_custom_plugins.c
@@ -1,0 +1,118 @@
+//
+// Created by Sbarex on 10/02/26.
+//
+
+#include "test_helpers.h"
+#include "apex/apex.h"
+#include <stdlib.h>
+
+
+/* cmark-gfm headers */
+#include "cmark-gfm.h"
+#include <string.h>
+
+static char * my_plugin_callback(const char *text, __attribute__((unused)) apex_plugin *plugin, apex_plugin_phase_mask phase_mask, __attribute__((unused)) const apex_options *options) {
+    if (phase_mask & APEX_PLUGIN_PHASE_PRE_PARSE) {
+        const char *suffix = "\n_Hello Sbarex_\n";
+        size_t len1 = strlen(text);
+        size_t len2 = strlen(suffix);
+
+        char *result = malloc(len1 + len2 + 1);
+        if (!result) return NULL;
+
+        memcpy(result, text, len1);
+        memcpy(result + len1, suffix, len2 + 1); // include '\0'
+        return result;
+    } else if (phase_mask & APEX_PLUGIN_PHASE_POST_RENDER) {
+        const char *suffix = "\n<p>Everything is fine</p>";
+        size_t len1 = strlen(text);
+        size_t len2 = strlen(suffix);
+
+        char *result = malloc(len1 + len2 + 1);
+        if (!result) return NULL;
+
+        memcpy(result, text, len1);
+        memcpy(result + len1, suffix, len2 + 1);
+        return result;
+    }
+    return NULL;
+}
+
+static void my_plugin_register(apex_plugin_manager *manager, __attribute__((unused)) const apex_options *options) {
+    apex_plugin *plugin1 = init_plugin();
+
+    plugin1->id = strdup("my_plugin");
+    plugin1->title = strdup("my_plugin title");
+    plugin1->author = strdup("sbarex");
+    plugin1->description = NULL;
+    plugin1->homepage = NULL;
+    plugin1->repo = NULL;
+    plugin1->phases = APEX_PLUGIN_PHASE_PRE_PARSE;
+    plugin1->handler_command = NULL;
+    plugin1->priority = 100;
+    plugin1->timeout_ms = 0;
+    plugin1->has_regex = 0;
+    plugin1->replacement = NULL;
+    plugin1->replacement = NULL;
+    plugin1->dir_path = NULL;
+    plugin1->support_dir = NULL;
+    plugin1->pattern = NULL;
+    plugin1->callback = my_plugin_callback;
+
+    printf(COLOR_GREEN "✓" COLOR_RESET " Custom plugin register callback called\n");
+
+    /* Attach to appropriate phase lists, enforcing per-list id uniqueness */
+    if (plugin_register(manager, plugin1)) {
+        printf(COLOR_GREEN "✓" COLOR_RESET " Custom plugin has been registered for pre parse\n");
+    } else {
+        printf(COLOR_RED "✗" COLOR_RESET " Custom plugin has not been registered for pre parse\n");
+    }
+
+    apex_plugin *plugin2 = init_plugin();
+
+    plugin2->id = strdup("my_plugin");
+    plugin2->title = strdup("my_plugin title");
+    plugin2->author = strdup("sbarex");
+    plugin2->description = NULL;
+    plugin2->homepage = NULL;
+    plugin2->repo = NULL;
+    plugin2->phases = APEX_PLUGIN_PHASE_POST_RENDER;
+    plugin2->handler_command = NULL;
+    plugin2->priority = 100;
+    plugin2->timeout_ms = 0;
+    plugin2->has_regex = 0;
+    plugin2->replacement = NULL;
+    plugin2->replacement = NULL;
+    plugin2->dir_path = NULL;
+    plugin2->support_dir = NULL;
+    plugin2->pattern = NULL;
+    plugin2->callback = my_plugin_callback;
+
+    /* Attach to appropriate phase lists, enforcing per-list id uniqueness */
+    if (plugin_register(manager, plugin2)) {
+        printf(COLOR_GREEN "✓" COLOR_RESET " Custom plugin has been registered for post render\n");
+    } else {
+        printf(COLOR_RED "✗" COLOR_RESET " Custom plugin has not been registered for post render\n");
+    }
+}
+
+void test_custom_plugins(void) {
+    int suite_failures = suite_start();
+    print_suite_title("Custom plugins Tests", false, true);
+
+    apex_options opts = apex_options_default();
+    opts.enable_plugins = true;
+    opts.allow_external_plugin_detection = false;
+    opts.plugin_register = my_plugin_register;
+
+    const char *s = "# Custom plugin callback test\n\n";
+
+    char *html;
+    html = apex_markdown_to_html(s, strlen(s), &opts);
+    assert_contains(html, "<em>Hello Sbarex</em>", "Custom pre parse plugin executed");
+    assert_contains(html, "<p>Everything is fine</p>", "Custom post render plugin executed");
+    apex_free_string(html);
+
+    bool had_failures = suite_end(suite_failures);
+    print_suite_title("Cmark Callbacks Tests", had_failures, false);
+}

--- a/tests/test_custom_plugins.c
+++ b/tests/test_custom_plugins.c
@@ -11,7 +11,7 @@
 #include "cmark-gfm.h"
 #include <string.h>
 
-static char * my_plugin_callback(const char *text, __attribute__((unused)) apex_plugin *plugin, apex_plugin_phase_mask phase_mask, __attribute__((unused)) const apex_options *options) {
+static char * my_plugin_callback(const char *text, __attribute__((unused)) const char *id_plugin, apex_plugin_phase_mask phase_mask, __attribute__((unused)) const apex_options *options) {
     if (phase_mask & APEX_PLUGIN_PHASE_PRE_PARSE) {
         const char *suffix = "\n_Hello Sbarex_\n";
         size_t len1 = strlen(text);
@@ -39,57 +39,17 @@ static char * my_plugin_callback(const char *text, __attribute__((unused)) apex_
 }
 
 static void my_plugin_register(apex_plugin_manager *manager, __attribute__((unused)) const apex_options *options) {
-    apex_plugin *plugin1 = init_plugin();
-
-    plugin1->id = strdup("my_plugin");
-    plugin1->title = strdup("my_plugin title");
-    plugin1->author = strdup("sbarex");
-    plugin1->description = NULL;
-    plugin1->homepage = NULL;
-    plugin1->repo = NULL;
-    plugin1->phases = APEX_PLUGIN_PHASE_PRE_PARSE;
-    plugin1->handler_command = NULL;
-    plugin1->priority = 100;
-    plugin1->timeout_ms = 0;
-    plugin1->has_regex = 0;
-    plugin1->replacement = NULL;
-    plugin1->replacement = NULL;
-    plugin1->dir_path = NULL;
-    plugin1->support_dir = NULL;
-    plugin1->pattern = NULL;
-    plugin1->callback = my_plugin_callback;
-
     printf(COLOR_GREEN "✓" COLOR_RESET " Custom plugin register callback called\n");
 
     /* Attach to appropriate phase lists, enforcing per-list id uniqueness */
-    if (plugin_register(manager, plugin1)) {
+    if (apex_plugin_register(manager, "my_plugin", APEX_PLUGIN_PHASE_PRE_PARSE, my_plugin_callback)) {
         printf(COLOR_GREEN "✓" COLOR_RESET " Custom plugin has been registered for pre parse\n");
     } else {
         printf(COLOR_RED "✗" COLOR_RESET " Custom plugin has not been registered for pre parse\n");
     }
 
-    apex_plugin *plugin2 = init_plugin();
-
-    plugin2->id = strdup("my_plugin");
-    plugin2->title = strdup("my_plugin title");
-    plugin2->author = strdup("sbarex");
-    plugin2->description = NULL;
-    plugin2->homepage = NULL;
-    plugin2->repo = NULL;
-    plugin2->phases = APEX_PLUGIN_PHASE_POST_RENDER;
-    plugin2->handler_command = NULL;
-    plugin2->priority = 100;
-    plugin2->timeout_ms = 0;
-    plugin2->has_regex = 0;
-    plugin2->replacement = NULL;
-    plugin2->replacement = NULL;
-    plugin2->dir_path = NULL;
-    plugin2->support_dir = NULL;
-    plugin2->pattern = NULL;
-    plugin2->callback = my_plugin_callback;
-
     /* Attach to appropriate phase lists, enforcing per-list id uniqueness */
-    if (plugin_register(manager, plugin2)) {
+    if (apex_plugin_register(manager, "my_plugin", APEX_PLUGIN_PHASE_POST_RENDER, my_plugin_callback)) {
         printf(COLOR_GREEN "✓" COLOR_RESET " Custom plugin has been registered for post render\n");
     } else {
         printf(COLOR_RED "✗" COLOR_RESET " Custom plugin has not been registered for post render\n");

--- a/tests/test_runner.c
+++ b/tests/test_runner.c
@@ -41,6 +41,7 @@ void test_math(void);
 void test_critic_markup(void);
 void test_cmark_init_callback(void);
 void test_cmark_callback(void);
+void test_custom_plugins(void);
 void test_processor_modes(void);
 void test_multimarkdown_image_attributes(void);
 void test_file_includes(void);
@@ -149,8 +150,8 @@ static test_suite suites[] = {
     { "citations",                     test_citations },
     { "aria_labels",                   test_aria_labels },
     { "marked_integration",            test_marked_integration_features },
-    { "marked",                        test_marked_integration_features },
     { "plugins_integration",           test_plugins_integration },
+    { "plugins_custom",                test_custom_plugins },
     { "ast_json",                      test_ast_json_parser },
 };
 


### PR DESCRIPTION
This PR adds a new callback function to `apex_options` to allow plugin registration from code.
A callback function has been added to the plugin struct to be executed if no external command or regular expression is defined.